### PR TITLE
Fix Crash On Empty Files

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -8,7 +8,7 @@ if not exist "bin" (mkdir bin)
 
 pushd bin
 
-set FLAGS=/fsanitize=address /EHsc /MP /Zi /W4
+set FLAGS=/EHsc /MP /Zi /W4
 rem set set FLAGS=/Ox /MP /GL
 
 set SYSTEM_LIBS=User32.lib Gdi32.lib

--- a/source/editor.cpp
+++ b/source/editor.cpp
@@ -26,6 +26,7 @@ internal void MoveGapToCursor(GapBuffer* gb) {
     } else if (gb->cur_pos < gb->gap_start) {
 
         int shift = gb->gap_start - gb->cur_pos;
+        if (shift <= 0 || shift >= GET_GAP_SIZE(gb)) return;
 
         void* src  = (void*)&(gb->data.chars[gb->cur_pos]);
         void* dest = (void*)&(gb->data.chars[gb->gap_end - shift + 1]);
@@ -40,6 +41,7 @@ internal void MoveGapToCursor(GapBuffer* gb) {
     } else {
 
         int shift = gb->cur_pos - gb->gap_end;
+        if (shift <= 0 || shift >= GET_GAP_SIZE(gb)) return;
 
         void* src  = (void*)&(gb->data.chars[gb->gap_end + 1]);
         void* dest = (void*)&(gb->data.chars[gb->gap_start]);


### PR DESCRIPTION
Fixes #4

The crash was caused by the sanitizer flag in the debug build. for now I have just removed the address sanitizer flag and everything works as expected for new files.